### PR TITLE
Fix ruby example

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2
+FROM ruby:2.6
 
 RUN echo $(ruby --version)
 
@@ -6,8 +6,7 @@ ADD . /src
 WORKDIR /src
 
 RUN bundle install
-RUN gem install faraday_middleware
-RUN gem install faker
+
 RUN sed -i 's/CipherString = DEFAULT@SECLEVEL=2/CipherString = DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf
 
 CMD ["ruby", "example.rb"]

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -6,7 +6,8 @@ ADD . /src
 WORKDIR /src
 
 RUN bundle install
-
+RUN gem install faraday_middleware
+RUN gem install faker
 RUN sed -i 's/CipherString = DEFAULT@SECLEVEL=2/CipherString = DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf
 
 CMD ["ruby", "example.rb"]

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'faraday', '0.10.0'
-gem 'faraday_middleware', '0.10.1'
-gem 'faker', '1.8.4'
+gem 'faraday', '0.17.3'
+gem 'faraday_middleware', '0.13.1'
+gem 'faker', '2.10.0'


### PR DESCRIPTION
## Fixes https://app.clubhouse.io/vgs/story/54892/fix-failing-circleci-tests

Downgrade ruby docker from latest to 2.6. For some reason `bundle install` not working properly on  latest version